### PR TITLE
Fix bugs from code review: crashes, GPS/SpO2 accuracy, throttling, rate limiting

### DIFF
--- a/OpenHiker iOS/Services/ElevationDataManager.swift
+++ b/OpenHiker iOS/Services/ElevationDataManager.swift
@@ -69,6 +69,11 @@ actor ElevationDataManager {
     /// Each entry holds the full 3601×3601 grid of Int16 elevation samples.
     private var loadedTiles: [String: [Int16]] = [:]
 
+    /// Least-recently-used order for ``loadedTiles`` (front = oldest). A Dictionary's
+    /// key order is undefined, so this array is required to evict the actual oldest
+    /// tile rather than an arbitrary one.
+    private var loadedTileOrder: [String] = []
+
     /// Directory where downloaded HGT files are cached on disk.
     private let cacheDirectory: URL
 
@@ -183,6 +188,7 @@ actor ElevationDataManager {
     /// Clear all cached elevation tiles from disk and memory.
     func clearCache() throws {
         loadedTiles.removeAll()
+        loadedTileOrder.removeAll()
         if FileManager.default.fileExists(atPath: cacheDirectory.path) {
             try FileManager.default.removeItem(at: cacheDirectory)
             try FileManager.default.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
@@ -195,6 +201,7 @@ actor ElevationDataManager {
     /// will reload tiles from disk on demand.
     func clearMemoryCache() {
         loadedTiles.removeAll()
+        loadedTileOrder.removeAll()
     }
 
     // MARK: - Tile Loading
@@ -206,6 +213,7 @@ actor ElevationDataManager {
     private func loadTile(_ tileName: String) async throws -> [Int16] {
         // Memory cache
         if let cached = loadedTiles[tileName] {
+            touchTile(tileName)
             return cached
         }
 
@@ -221,7 +229,18 @@ actor ElevationDataManager {
 
         let grid = try readHGT(at: diskPath)
         loadedTiles[tileName] = grid
+        touchTile(tileName)
         return grid
+    }
+
+    /// Marks a tile as most-recently-used in the LRU order.
+    ///
+    /// - Parameter tileName: The tile that was just accessed or inserted.
+    private func touchTile(_ tileName: String) {
+        if let index = loadedTileOrder.firstIndex(of: tileName) {
+            loadedTileOrder.remove(at: index)
+        }
+        loadedTileOrder.append(tileName)
     }
 
     /// Read an HGT file from disk into an array of Int16 elevation samples.
@@ -557,15 +576,15 @@ actor ElevationDataManager {
         return names
     }
 
-    /// Evict the oldest tile from the memory cache when it exceeds ``maxCachedTiles``.
+    /// Evict the least-recently-used tile(s) from the memory cache when it reaches
+    /// ``maxCachedTiles``.
     ///
-    /// Uses a simple FIFO strategy: removes an arbitrary entry when the cache
-    /// is full. This bounds memory usage to approximately `maxCachedTiles × 25 MB`.
+    /// Uses the ``loadedTileOrder`` LRU list to remove the genuinely oldest entry.
+    /// This bounds memory usage to approximately `maxCachedTiles × 25 MB`.
     private func evictTileIfNeeded() {
-        while loadedTiles.count >= Self.maxCachedTiles {
-            if let key = loadedTiles.keys.first {
-                loadedTiles.removeValue(forKey: key)
-            }
+        while loadedTiles.count >= Self.maxCachedTiles, !loadedTileOrder.isEmpty {
+            let oldest = loadedTileOrder.removeFirst()
+            loadedTiles.removeValue(forKey: oldest)
         }
     }
 }

--- a/OpenHiker iOS/Services/ElevationDataManager.swift
+++ b/OpenHiker iOS/Services/ElevationDataManager.swift
@@ -242,9 +242,13 @@ actor ElevationDataManager {
         data.withUnsafeBytes { buffer in
             let bytes = buffer.bindMemory(to: UInt8.self)
             for i in 0..<grid.count {
-                let hi = Int16(bytes[i * 2])
-                let lo = Int16(bytes[i * 2 + 1])
-                grid[i] = (hi << 8) | lo  // Big-endian
+                // Assemble the big-endian sample in an UNSIGNED 16-bit value first,
+                // then reinterpret the bit pattern as signed. Shifting directly on Int16
+                // traps whenever the high byte is >= 0x80 (e.g. the standard SRTM void
+                // marker 0x8000) because the intermediate value exceeds Int16.max.
+                let hi = UInt16(bytes[i * 2])
+                let lo = UInt16(bytes[i * 2 + 1])
+                grid[i] = Int16(bitPattern: (hi << 8) | lo)  // Big-endian
             }
         }
         return grid

--- a/OpenHiker iOS/Services/PBFParser.swift
+++ b/OpenHiker iOS/Services/PBFParser.swift
@@ -289,16 +289,54 @@ actor PBFParser {
             sourceData = data
         }
 
-        let bufferSize = max(expectedSize, sourceData.count * 4)
-        var destinationBuffer = Data(count: bufferSize)
+        // When raw_size is known (the OSM PBF spec always provides it for zlib
+        // blobs) the output must be exactly that size. Otherwise fall back to a
+        // grow-and-retry loop. compression_decode_buffer does NOT signal an error
+        // when the destination is too small -- it just returns the bytes that fit --
+        // so a fixed multiplier could silently truncate the block. We therefore
+        // verify the output length and never accept a partial result.
+        if expectedSize > 0 {
+            let output = try decodeZlib(sourceData, into: expectedSize)
+            guard output.count == expectedSize else {
+                // Short output means the stream was corrupt/truncated.
+                throw ParseError.decompressError
+            }
+            return output
+        }
 
+        // Unknown raw_size: grow the buffer until the whole stream fits.
+        var bufferSize = max(sourceData.count * 4, 1024)
+        let maxBufferSize = sourceData.count * 1024  // generous ceiling vs. zlib ratios
+        while true {
+            let output = try decodeZlib(sourceData, into: bufferSize)
+            // If the decoder filled the entire buffer, output may be truncated;
+            // grow and retry. A smaller-than-buffer result is guaranteed complete.
+            if output.count < bufferSize {
+                return output
+            }
+            if bufferSize >= maxBufferSize {
+                throw ParseError.decompressError
+            }
+            bufferSize = min(bufferSize * 2, maxBufferSize)
+        }
+    }
+
+    /// Decodes a raw DEFLATE stream into a buffer of the given capacity.
+    ///
+    /// - Parameters:
+    ///   - sourceData: The raw DEFLATE bytes (zlib header already stripped).
+    ///   - capacity: The destination buffer size in bytes.
+    /// - Returns: The decoded bytes (length = bytes actually written).
+    /// - Throws: ``ParseError/decompressError`` if the decoder reports failure.
+    private func decodeZlib(_ sourceData: Data, into capacity: Int) throws -> Data {
+        var destinationBuffer = Data(count: capacity)
         let decompressedSize = sourceData.withUnsafeBytes { srcPtr -> Int in
             destinationBuffer.withUnsafeMutableBytes { dstPtr -> Int in
                 guard let srcBase = srcPtr.baseAddress,
                       let dstBase = dstPtr.baseAddress else { return 0 }
                 return compression_decode_buffer(
                     dstBase.assumingMemoryBound(to: UInt8.self),
-                    bufferSize,
+                    capacity,
                     srcBase.assumingMemoryBound(to: UInt8.self),
                     sourceData.count,
                     nil,

--- a/OpenHiker iOS/Services/TileDownloader.swift
+++ b/OpenHiker iOS/Services/TileDownloader.swift
@@ -119,8 +119,12 @@ actor TileDownloader {
     /// Cache hits bypass this throttle entirely.
     private static let minRequestIntervalNs: UInt64 = 50_000_000
 
-    /// Timestamp of the last network request, used for per-request rate limiting.
-    private var lastNetworkRequestTime: ContinuousClock.Instant = .now
+    /// The instant at which the next network request is allowed to fire.
+    ///
+    /// Used as a reservation cursor for per-request rate limiting: each caller
+    /// advances it by ``minRequestIntervalNs`` *before* suspending, so concurrent
+    /// callers stagger onto distinct slots rather than all reading a stale value.
+    private var nextRequestSlot: ContinuousClock.Instant = .now
 
     /// Creates a new tile downloader with a configured URL session and cache directory.
     ///
@@ -273,12 +277,20 @@ actor TileDownloader {
     /// Enforces minimum spacing between network requests to avoid overloading tile servers.
     /// Cache hits do not call this method and proceed at full speed.
     private func throttleIfNeeded() async throws {
-        let elapsed = lastNetworkRequestTime.duration(to: .now)
+        // Reserve the next slot synchronously, while actor isolation is held and
+        // before any suspension point. This advance is atomic per call, so N
+        // concurrent callers claim N distinct, staggered slots. If we instead
+        // recorded the timestamp *after* sleeping, suspended callers would all read
+        // the same stale value and fire as a burst, defeating the throttle.
         let minInterval = Duration.nanoseconds(Self.minRequestIntervalNs)
-        if elapsed < minInterval {
-            try await Task.sleep(for: minInterval - elapsed)
+        let now = ContinuousClock.now
+        let slot = max(now, nextRequestSlot)
+        nextRequestSlot = slot + minInterval
+
+        let waitUntilSlot = now.duration(to: slot)
+        if waitUntilSlot > .zero {
+            try await Task.sleep(for: waitUntilSlot)
         }
-        lastNetworkRequestTime = .now
     }
 
     /// Downloads a single tile from the server, checking the local cache first.

--- a/OpenHiker iOS/Services/TileDownloader.swift
+++ b/OpenHiker iOS/Services/TileDownloader.swift
@@ -283,7 +283,7 @@ actor TileDownloader {
         // recorded the timestamp *after* sleeping, suspended callers would all read
         // the same stale value and fire as a burst, defeating the throttle.
         let minInterval = Duration.nanoseconds(Self.minRequestIntervalNs)
-        let now = ContinuousClock.now
+        let now: ContinuousClock.Instant = .now
         let slot = max(now, nextRequestSlot)
         nextRequestSlot = slot + minInterval
 

--- a/OpenHiker iOS/Services/iOSLocationManager.swift
+++ b/OpenHiker iOS/Services/iOSLocationManager.swift
@@ -75,6 +75,13 @@ final class iOSLocationManager: NSObject, ObservableObject {
     /// Recorded GPS points during the current hike track.
     @Published var trackPoints: [CLLocation] = []
 
+    /// The last recorded point with acceptable horizontal accuracy (< 100 m).
+    ///
+    /// Cumulative distance and elevation are measured from this anchor rather than
+    /// from the immediately preceding track point, so low-accuracy jitter points
+    /// (which are still recorded for visual continuity) do not inflate the totals.
+    private var lastHighAccuracyPoint: CLLocation?
+
     /// Total distance of the current track in meters (incrementally updated).
     @Published private(set) var totalDistance: CLLocationDistance = 0
 
@@ -254,6 +261,7 @@ final class iOSLocationManager: NSObject, ObservableObject {
         }
 
         trackPoints.removeAll()
+        lastHighAccuracyPoint = nil
         totalDistance = 0
         elevationGain = 0
         elevationLoss = 0
@@ -397,6 +405,10 @@ final class iOSLocationManager: NSObject, ObservableObject {
             }
         }
 
+        // Re-anchor distance accumulation on the last accurate restored point so the
+        // first segment after recovery is measured (not silently dropped).
+        lastHighAccuracyPoint = trackPoints.last { $0.horizontalAccuracy >= 0 && $0.horizontalAccuracy < 100 }
+
         // Restore stats
         if let data = try? Data(contentsOf: Self.trackStatsFileURL),
            let stats = try? JSONSerialization.jsonObject(with: data) as? [String: Double] {
@@ -468,13 +480,18 @@ extension iOSLocationManager: CLLocationManagerDelegate {
             if let lastPoint = trackPoints.last {
                 let distance = location.distance(from: lastPoint)
                 if distance >= gpsMode.distanceFilter {
-                    // Only update elevation stats for high-accuracy points to avoid
-                    // barometric altitude noise from degraded GPS readings
+                    // Accumulate distance and elevation only between high-accuracy
+                    // points, measured from the last high-accuracy anchor. A noisy
+                    // (>=100m) reading can sit ~100m from the true path, so counting
+                    // its distance would over-report the total (the watch avoids this
+                    // by dropping such points entirely). Low-accuracy points are still
+                    // appended to the track for visual continuity, but contribute no
+                    // distance and the span across them is measured from the anchor.
                     if isHighAccuracy {
-                        updateCachedStats(from: lastPoint, to: location)
-                    } else {
-                        // Still count distance even for low-accuracy points
-                        totalDistance += distance
+                        if let anchor = lastHighAccuracyPoint {
+                            updateCachedStats(from: anchor, to: location)
+                        }
+                        lastHighAccuracyPoint = location
                     }
                     trackPoints.append(location)
 
@@ -485,6 +502,9 @@ extension iOSLocationManager: CLLocationManagerDelegate {
                 }
             } else {
                 trackPoints.append(location)
+                if isHighAccuracy {
+                    lastHighAccuracyPoint = location
+                }
             }
         }
     }

--- a/OpenHiker iOS/Services/iOSRouteGuidance.swift
+++ b/OpenHiker iOS/Services/iOSRouteGuidance.swift
@@ -271,9 +271,13 @@ final class iOSRouteGuidance: ObservableObject {
         segStart: CLLocationCoordinate2D,
         segEnd: CLLocationCoordinate2D
     ) -> (point: CLLocationCoordinate2D, fraction: Double) {
-        let dx = segEnd.longitude - segStart.longitude
+        // Longitude degrees are scaled by cos(latitude) so the projection is computed
+        // in an isotropic (metric) space; otherwise distance-along-route is skewed on
+        // diagonal segments, with the error growing toward higher latitudes.
+        let lonScale = cos(segStart.latitude * .pi / 180)
+        let dx = (segEnd.longitude - segStart.longitude) * lonScale
         let dy = segEnd.latitude - segStart.latitude
-        let px = point.longitude - segStart.longitude
+        let px = (point.longitude - segStart.longitude) * lonScale
         let py = point.latitude - segStart.latitude
 
         let segLengthSquared = dx * dx + dy * dy
@@ -284,8 +288,9 @@ final class iOSRouteGuidance: ObservableObject {
 
         let t = max(0, min(1, (px * dx + py * dy) / segLengthSquared))
 
-        let projectedLat = segStart.latitude + t * dy
-        let projectedLon = segStart.longitude + t * dx
+        // Interpolate with the original (unscaled) coordinates; t is metric-agnostic.
+        let projectedLat = segStart.latitude + t * (segEnd.latitude - segStart.latitude)
+        let projectedLon = segStart.longitude + t * (segEnd.longitude - segStart.longitude)
 
         return (
             point: CLLocationCoordinate2D(latitude: projectedLat, longitude: projectedLon),

--- a/OpenHiker watchOS/Services/HealthKitManager.swift
+++ b/OpenHiker watchOS/Services/HealthKitManager.swift
@@ -499,9 +499,13 @@ final class HealthKitManager: NSObject, ObservableObject, @unchecked Sendable {
     private func processSpO2Samples(_ samples: [HKSample]?) {
         guard let samples = samples as? [HKQuantitySample], !samples.isEmpty else { return }
 
+        // HKUnit.percent() yields a 0...100 value, but `currentSpO2`/`spO2Samples`
+        // are defined as a fraction (0.0...1.0) and the UI formatter multiplies by
+        // 100 again. Convert to a fraction here so the value is not scaled twice
+        // (otherwise 0.97 would display as "9700%").
         let percentUnit = HKUnit.percent()
 
-        let spO2Values = samples.map { $0.quantity.doubleValue(for: percentUnit) }
+        let spO2Values = samples.map { $0.quantity.doubleValue(for: percentUnit) / 100.0 }
         samplesQueue.sync {
             spO2Samples.append(contentsOf: spO2Values)
         }
@@ -509,7 +513,7 @@ final class HealthKitManager: NSObject, ObservableObject, @unchecked Sendable {
         if let latestSample = samples.last {
             let age = Date().timeIntervalSince(latestSample.endDate)
             if age < HikeStatisticsConfig.spO2MaxAgeSec {
-                let value = latestSample.quantity.doubleValue(for: percentUnit)
+                let value = latestSample.quantity.doubleValue(for: percentUnit) / 100.0
                 DispatchQueue.main.async {
                     self.currentSpO2 = value
                 }

--- a/OpenHiker watchOS/Services/MapRenderer.swift
+++ b/OpenHiker watchOS/Services/MapRenderer.swift
@@ -341,6 +341,13 @@ final class MapScene: SKScene {
     /// In-memory cache of tile textures to avoid re-creating them from PNG data.
     private var textureCache: [TileCoordinate: SKTexture] = [:]
 
+    /// Insertion/most-recently-used order for ``textureCache``, used for eviction.
+    ///
+    /// A `Dictionary`'s key order is undefined, so the cache cannot derive an
+    /// "oldest" entry from its keys. This array tracks access order so eviction is
+    /// a true least-recently-used policy: the front is the oldest used tile.
+    private var textureCacheOrder: [TileCoordinate] = []
+
     /// Maximum number of textures to keep in the cache before evicting old entries.
     private let maxCacheSize = 100
 
@@ -589,34 +596,21 @@ final class MapScene: SKScene {
     ///
     /// - Parameter tile: The ``TileCoordinate`` to create a sprite for.
     private func addTileSprite(for tile: TileCoordinate) {
-        guard let renderer = renderer,
-              let tileData = renderer.getTileData(for: tile) else {
-            // No tile data - show placeholder
-            addPlaceholderTile(for: tile)
-            return
-        }
-
-        // Create texture from tile data
-        #if os(watchOS)
-        guard let uiImage = UIImage(data: tileData) else {
-            addPlaceholderTile(for: tile)
-            return
-        }
-        #else
-        guard let uiImage = UIImage(data: tileData) else {
-            addPlaceholderTile(for: tile)
-            return
-        }
-        #endif
-
-        let texture = SKTexture(image: uiImage)
-        textureCache[tile] = texture
-
-        // Manage cache size
-        if textureCache.count > maxCacheSize {
-            // Remove oldest entries (simple FIFO for now)
-            let keysToRemove = Array(textureCache.keys.prefix(textureCache.count - maxCacheSize))
-            keysToRemove.forEach { textureCache.removeValue(forKey: $0) }
+        // Serve from the texture cache when possible to avoid re-querying SQLite
+        // and re-decoding the PNG every time the tile re-enters the visible grid.
+        let texture: SKTexture
+        if let cached = cachedTexture(for: tile) {
+            texture = cached
+        } else {
+            guard let renderer = renderer,
+                  let tileData = renderer.getTileData(for: tile),
+                  let uiImage = UIImage(data: tileData) else {
+                // No tile data - show placeholder
+                addPlaceholderTile(for: tile)
+                return
+            }
+            texture = SKTexture(image: uiImage)
+            store(texture: texture, for: tile)
         }
 
         let sprite = SKSpriteNode(texture: texture)
@@ -625,6 +619,37 @@ final class MapScene: SKScene {
         sprite.anchorPoint = CGPoint(x: 0.5, y: 0.5)
 
         tilesNode.addChild(sprite)
+    }
+
+    /// Returns a cached texture for the tile, if present, marking it most-recently-used.
+    ///
+    /// - Parameter tile: The tile to look up.
+    /// - Returns: The cached ``SKTexture``, or `nil` on a cache miss.
+    private func cachedTexture(for tile: TileCoordinate) -> SKTexture? {
+        guard let texture = textureCache[tile] else { return nil }
+        if let index = textureCacheOrder.firstIndex(of: tile) {
+            textureCacheOrder.remove(at: index)
+        }
+        textureCacheOrder.append(tile)
+        return texture
+    }
+
+    /// Inserts a texture into the cache, evicting the least-recently-used entries
+    /// once the cache exceeds ``maxCacheSize``.
+    ///
+    /// - Parameters:
+    ///   - texture: The texture to cache.
+    ///   - tile: The tile key.
+    private func store(texture: SKTexture, for tile: TileCoordinate) {
+        if textureCache[tile] == nil {
+            textureCacheOrder.append(tile)
+        }
+        textureCache[tile] = texture
+
+        while textureCache.count > maxCacheSize, !textureCacheOrder.isEmpty {
+            let oldest = textureCacheOrder.removeFirst()
+            textureCache.removeValue(forKey: oldest)
+        }
     }
 
     /// Creates a gray placeholder tile with coordinate labels for debugging.

--- a/OpenHiker watchOS/Services/RouteGuidance.swift
+++ b/OpenHiker watchOS/Services/RouteGuidance.swift
@@ -284,10 +284,15 @@ final class RouteGuidance: ObservableObject {
         segStart: CLLocationCoordinate2D,
         segEnd: CLLocationCoordinate2D
     ) -> (point: CLLocationCoordinate2D, fraction: Double) {
-        // Convert to a local planar coordinate system for projection
-        let dx = segEnd.longitude - segStart.longitude
+        // Convert to a local planar coordinate system for projection. Longitude
+        // degrees are scaled by cos(latitude) so 1 unit east ~= 1 unit north in
+        // metres; without this, the fraction is computed in a distorted space and
+        // distance-along-route is skewed on diagonal segments (the error grows with
+        // latitude, e.g. ~0.68x at 47 degrees).
+        let lonScale = cos(segStart.latitude * .pi / 180)
+        let dx = (segEnd.longitude - segStart.longitude) * lonScale
         let dy = segEnd.latitude - segStart.latitude
-        let px = point.longitude - segStart.longitude
+        let px = (point.longitude - segStart.longitude) * lonScale
         let py = point.latitude - segStart.latitude
 
         let segLengthSquared = dx * dx + dy * dy
@@ -299,8 +304,10 @@ final class RouteGuidance: ObservableObject {
         // Fraction along the segment (clamped to 0-1)
         let t = max(0, min(1, (px * dx + py * dy) / segLengthSquared))
 
-        let projectedLat = segStart.latitude + t * dy
-        let projectedLon = segStart.longitude + t * dx
+        // Interpolate the position with the original (unscaled) coordinates; the
+        // fraction t is metric-agnostic, so linear interpolation in lat/lon is exact.
+        let projectedLat = segStart.latitude + t * (segEnd.latitude - segStart.latitude)
+        let projectedLon = segStart.longitude + t * (segEnd.longitude - segStart.longitude)
 
         return (
             point: CLLocationCoordinate2D(latitude: projectedLat, longitude: projectedLon),

--- a/Shared/Models/TileCoordinate.swift
+++ b/Shared/Models/TileCoordinate.swift
@@ -61,14 +61,28 @@ struct TileCoordinate: Hashable, Codable, Sendable {
     ///   - zoom: The desired zoom level.
     init(latitude: Double, longitude: Double, zoom: Int) {
         self.z = zoom
+        let maxIndex = (1 << zoom) - 1
         let n = Double(1 << zoom)
 
-        // Convert longitude to tile X
-        self.x = Int(floor((longitude + 180.0) / 360.0 * n))
+        // Normalize longitude into [-180, 180) so values outside that range (e.g.
+        // a bounding box that wraps the antimeridian) don't produce out-of-range
+        // tile columns.
+        var lon = longitude.truncatingRemainder(dividingBy: 360.0)
+        if lon < -180.0 { lon += 360.0 }
+        if lon >= 180.0 { lon -= 360.0 }
 
-        // Convert latitude to tile Y using Web Mercator projection
-        let latRad = latitude * .pi / 180.0
-        self.y = Int(floor((1.0 - asinh(tan(latRad)) / .pi) / 2.0 * n))
+        // Clamp latitude to the Web Mercator limit; beyond it tan() diverges and
+        // would yield a NaN / out-of-range row.
+        let clampedLat = min(max(latitude, -85.05112878), 85.05112878)
+
+        // Convert longitude to tile X, clamped to the valid axis range.
+        let rawX = Int(floor((lon + 180.0) / 360.0 * n))
+        self.x = min(max(rawX, 0), maxIndex)
+
+        // Convert latitude to tile Y using Web Mercator projection, clamped likewise.
+        let latRad = clampedLat * .pi / 180.0
+        let rawY = Int(floor((1.0 - asinh(tan(latRad)) / .pi) / 2.0 * n))
+        self.y = min(max(rawY, 0), maxIndex)
     }
 
     /// Create a tile coordinate from explicit x, y, z values.
@@ -311,8 +325,21 @@ struct BoundingBox: Codable, Sendable, Equatable, Hashable {
 
         self.north = min(center.latitude + latDelta, 85.0)
         self.south = max(center.latitude - latDelta, -85.0)
-        self.east = center.longitude + lonDelta
-        self.west = center.longitude - lonDelta
+        // Normalize the east/west edges into [-180, 180) so a box centered near the
+        // antimeridian doesn't produce longitudes outside the valid range.
+        self.east = BoundingBox.normalizeLongitude(center.longitude + lonDelta)
+        self.west = BoundingBox.normalizeLongitude(center.longitude - lonDelta)
+    }
+
+    /// Wraps a longitude into the half-open range `[-180, 180)`.
+    ///
+    /// - Parameter longitude: A longitude in degrees, possibly outside the range.
+    /// - Returns: The equivalent longitude within `[-180, 180)`.
+    private static func normalizeLongitude(_ longitude: Double) -> Double {
+        var lon = longitude.truncatingRemainder(dividingBy: 360.0)
+        if lon < -180.0 { lon += 360.0 }
+        if lon >= 180.0 { lon -= 360.0 }
+        return lon
     }
 
     /// Check if a coordinate falls within this bounding box.

--- a/Shared/Models/TurnInstruction.swift
+++ b/Shared/Models/TurnInstruction.swift
@@ -461,7 +461,7 @@ enum TurnInstructionGenerator {
         edgeIndex: Int
     ) -> Double {
         let startNode = route.nodes[edgeIndex]
-        let intermediateCoords = EdgeGeometry.unpack(edge.geometry)
+        let intermediateCoords = orientedGeometry(for: edge, traversalStart: startNode)
 
         if let firstIntermediate = intermediateCoords.first {
             return BearingCalculator.bearing(from: startNode.coordinate, to: firstIntermediate)
@@ -482,14 +482,36 @@ enum TurnInstructionGenerator {
         edgeIndex: Int
     ) -> Double {
         let endNode = route.nodes[edgeIndex + 1]
-        let intermediateCoords = EdgeGeometry.unpack(edge.geometry)
+        let startNode = route.nodes[edgeIndex]
+        let intermediateCoords = orientedGeometry(for: edge, traversalStart: startNode)
 
         if let lastIntermediate = intermediateCoords.last {
             return BearingCalculator.bearing(from: lastIntermediate, to: endNode.coordinate)
         } else {
-            let startNode = route.nodes[edgeIndex]
             return BearingCalculator.bearing(from: startNode.coordinate, to: endNode.coordinate)
         }
+    }
+
+    /// Returns an edge's intermediate geometry oriented along the direction it is
+    /// actually traversed in the route.
+    ///
+    /// Edge geometry is stored once in canonical `fromNode → toNode` order, but the
+    /// router may traverse an edge in reverse. The bearing helpers need the geometry
+    /// in traversal order; otherwise the computed incoming/outgoing bearings point
+    /// backwards and turn directions are wrong on reverse-traversed edges.
+    ///
+    /// - Parameters:
+    ///   - edge: The edge whose geometry to orient.
+    ///   - traversalStart: The node at which traversal of this edge begins.
+    /// - Returns: Intermediate coordinates ordered from the traversal start.
+    private static func orientedGeometry(
+        for edge: RoutingEdge,
+        traversalStart: RoutingNode
+    ) -> [CLLocationCoordinate2D] {
+        let coords = EdgeGeometry.unpack(edge.geometry)
+        // If traversal begins at the edge's toNode, the edge is traversed reversed,
+        // so the canonical from→to geometry must be flipped.
+        return traversalStart.id == edge.toNode ? Array(coords.reversed()) : coords
     }
 
     /// Computes the initial bearing of an edge (from start toward destination).

--- a/Shared/Services/GitHubRouteService.swift
+++ b/Shared/Services/GitHubRouteService.swift
@@ -25,6 +25,8 @@ enum GitHubRouteError: Error, LocalizedError {
     case invalidResponse(String)
     /// The bot token is missing or invalid.
     case authenticationFailed
+    /// The GitHub API rate limit was hit; `retryAfter` is the suggested wait in seconds.
+    case rateLimited(retryAfter: TimeInterval?)
     /// A network request failed after all retry attempts.
     case networkError(Error)
     /// The route index could not be fetched or decoded.
@@ -40,6 +42,8 @@ enum GitHubRouteError: Error, LocalizedError {
             return "Invalid GitHub response: \(detail)"
         case .authenticationFailed:
             return "GitHub authentication failed — please check the app configuration"
+        case .rateLimited:
+            return "GitHub rate limit reached — please try again later"
         case .networkError(let error):
             return "Network error: \(error.localizedDescription)"
         case .indexFetchFailed(let detail):
@@ -93,6 +97,10 @@ actor GitHubRouteService {
 
     /// Base delay in seconds for exponential backoff (doubled on each retry).
     private static let baseRetryDelaySec: UInt64 = 2
+
+    /// Upper bound (seconds) on how long to wait for a rate-limit reset before
+    /// giving up, so a large `Retry-After`/reset value can't block indefinitely.
+    private static let maxRateLimitDelaySec: TimeInterval = 60
 
     /// User-Agent header value for API requests (required by GitHub).
     private static let userAgent = "OpenHiker/1.0 (iOS; community route sharing)"
@@ -642,8 +650,12 @@ actor GitHubRouteService {
     /// - Throws: ``GitHubRouteError`` if all retries are exhausted.
     private func performWithRetry(request: URLRequest) async throws -> Data {
         var lastError: Error?
+        // When set, overrides the exponential backoff for the next attempt (used to
+        // honor a rate-limit Retry-After / reset hint).
+        var nextDelayOverrideSec: UInt64?
 
         for attempt in 0..<Self.maxRetryAttempts {
+            nextDelayOverrideSec = nil
             do {
                 let (data, response) = try await session.data(for: request)
 
@@ -654,7 +666,20 @@ actor GitHubRouteService {
                 switch httpResponse.statusCode {
                 case 200...299:
                     return data
-                case 401, 403:
+                case 403, 429:
+                    // 403 is overloaded by GitHub: it means auth failure OR rate
+                    // limiting; 429 is always rate limiting. Distinguish by the
+                    // rate-limit headers and retry (honoring the reset hint) rather
+                    // than reporting a spurious authentication failure.
+                    if let retryAfter = Self.rateLimitRetryAfter(from: httpResponse) {
+                        lastError = GitHubRouteError.rateLimited(retryAfter: retryAfter)
+                        nextDelayOverrideSec = UInt64(min(max(retryAfter, 1), Self.maxRateLimitDelaySec))
+                    } else if httpResponse.statusCode == 403 {
+                        throw GitHubRouteError.authenticationFailed
+                    } else {
+                        lastError = GitHubRouteError.rateLimited(retryAfter: nil)
+                    }
+                case 401:
                     throw GitHubRouteError.authenticationFailed
                 case 400...499:
                     // Client errors — do not retry
@@ -679,9 +704,10 @@ actor GitHubRouteService {
                 lastError = error
             }
 
-            // Exponential backoff: 2s, 4s, 8s, 16s
+            // Exponential backoff (2s, 4s, 8s, 16s), unless a rate-limit hint
+            // overrides the delay for this attempt.
             if attempt < Self.maxRetryAttempts - 1 {
-                let delay = Self.baseRetryDelaySec * UInt64(1 << attempt)
+                let delay = nextDelayOverrideSec ?? (Self.baseRetryDelaySec * UInt64(1 << attempt))
                 try await Task.sleep(nanoseconds: delay * Self.nanosecondsPerSecond)
             }
         }
@@ -690,6 +716,42 @@ actor GitHubRouteService {
             throw error
         }
         throw GitHubRouteError.networkError(lastError ?? NSError(domain: "GitHubRouteService", code: -1))
+    }
+
+    /// Determines whether an HTTP response indicates GitHub rate limiting, and if
+    /// so, how long to wait before retrying.
+    ///
+    /// GitHub signals rate limiting via the `Retry-After` header (secondary limits)
+    /// or `x-ratelimit-remaining: 0` together with an `x-ratelimit-reset` epoch
+    /// (primary limits). A 403 without any of these is a genuine authorization
+    /// failure, not a rate limit.
+    ///
+    /// - Parameter response: The HTTP response to inspect.
+    /// - Returns: The suggested wait in seconds, or `nil` if not rate limited.
+    private static func rateLimitRetryAfter(from response: HTTPURLResponse) -> TimeInterval? {
+        let headers = response.allHeaderFields
+
+        // Secondary rate limit: explicit Retry-After (seconds).
+        if let retryAfter = headers["Retry-After"] as? String,
+           let seconds = TimeInterval(retryAfter.trimmingCharacters(in: .whitespaces)) {
+            return max(seconds, 1)
+        }
+
+        // Primary rate limit: remaining == 0, wait until the reset epoch.
+        if let remaining = (headers["x-ratelimit-remaining"] as? String)
+            ?? (headers["X-RateLimit-Remaining"] as? String),
+           remaining == "0" {
+            if let resetString = (headers["x-ratelimit-reset"] as? String)
+                ?? (headers["X-RateLimit-Reset"] as? String),
+               let resetEpoch = TimeInterval(resetString) {
+                let wait = resetEpoch - Date().timeIntervalSince1970
+                return max(wait, 1)
+            }
+            // Remaining is zero but no reset hint — wait the default backoff.
+            return TimeInterval(baseRetryDelaySec)
+        }
+
+        return nil
     }
 
     // MARK: - PR Description Builder

--- a/Shared/Services/GitHubRouteService.swift
+++ b/Shared/Services/GitHubRouteService.swift
@@ -729,20 +729,16 @@ actor GitHubRouteService {
     /// - Parameter response: The HTTP response to inspect.
     /// - Returns: The suggested wait in seconds, or `nil` if not rate limited.
     private static func rateLimitRetryAfter(from response: HTTPURLResponse) -> TimeInterval? {
-        let headers = response.allHeaderFields
-
+        // value(forHTTPHeaderField:) is case-insensitive, unlike allHeaderFields.
         // Secondary rate limit: explicit Retry-After (seconds).
-        if let retryAfter = headers["Retry-After"] as? String,
+        if let retryAfter = response.value(forHTTPHeaderField: "Retry-After"),
            let seconds = TimeInterval(retryAfter.trimmingCharacters(in: .whitespaces)) {
             return max(seconds, 1)
         }
 
         // Primary rate limit: remaining == 0, wait until the reset epoch.
-        if let remaining = (headers["x-ratelimit-remaining"] as? String)
-            ?? (headers["X-RateLimit-Remaining"] as? String),
-           remaining == "0" {
-            if let resetString = (headers["x-ratelimit-reset"] as? String)
-                ?? (headers["X-RateLimit-Reset"] as? String),
+        if response.value(forHTTPHeaderField: "x-ratelimit-remaining") == "0" {
+            if let resetString = response.value(forHTTPHeaderField: "x-ratelimit-reset"),
                let resetEpoch = TimeInterval(resetString) {
                 let wait = resetEpoch - Date().timeIntervalSince1970
                 return max(wait, 1)

--- a/Shared/Services/PeerTransferService.swift
+++ b/Shared/Services/PeerTransferService.swift
@@ -647,6 +647,12 @@ extension PeerTransferService: MCSessionDelegate {
     ///   - name: The resource name (e.g., `"manifest:<uuid>"`, `"mbtiles:<uuid>"`).
     ///   - localURL: The temporary file URL where the resource was saved.
     private func handleReceivedResource(name: String, at localURL: URL) {
+        // Guarantee the received temp file is removed on every exit path. For the
+        // mbtiles/routing cases this is a no-op on success (moveItem already
+        // consumed it) but reclaims the file on the early-return guard failures and
+        // save errors that previously leaked it.
+        defer { try? FileManager.default.removeItem(at: localURL) }
+
         let components = name.split(separator: ":", maxSplits: 1)
         guard components.count == 2 else {
             transferState = .failed("Invalid resource name: \(name)")
@@ -666,7 +672,6 @@ extension PeerTransferService: MCSessionDelegate {
             } catch {
                 transferState = .failed("Failed to decode manifest: \(error.localizedDescription)")
             }
-            try? FileManager.default.removeItem(at: localURL)
 
         case "mbtiles":
             guard let region = receivedManifest, region.id.uuidString == uuidString else {
@@ -718,7 +723,6 @@ extension PeerTransferService: MCSessionDelegate {
             } catch {
                 print("PeerTransferService: Failed to import saved routes: \(error.localizedDescription)")
             }
-            try? FileManager.default.removeItem(at: localURL)
 
         case "plannedroutes":
             do {
@@ -733,7 +737,6 @@ extension PeerTransferService: MCSessionDelegate {
             } catch {
                 print("PeerTransferService: Failed to import planned routes: \(error.localizedDescription)")
             }
-            try? FileManager.default.removeItem(at: localURL)
 
         case "waypoints":
             do {
@@ -748,7 +751,6 @@ extension PeerTransferService: MCSessionDelegate {
             } catch {
                 print("PeerTransferService: Failed to import waypoints: \(error.localizedDescription)")
             }
-            try? FileManager.default.removeItem(at: localURL)
 
         case "done":
             let regionName = receivedManifest?.name ?? "unknown"
@@ -756,11 +758,9 @@ extension PeerTransferService: MCSessionDelegate {
             progress = 1.0
             receivedManifest = nil
             print("PeerTransferService: Transfer complete for '\(regionName)'")
-            try? FileManager.default.removeItem(at: localURL)
 
         default:
             print("PeerTransferService: Unknown resource type '\(prefix)', ignoring")
-            try? FileManager.default.removeItem(at: localURL)
         }
     }
 }

--- a/Shared/Services/RoutingEngine.swift
+++ b/Shared/Services/RoutingEngine.swift
@@ -431,7 +431,14 @@ private struct AStarEntry: Comparable {
     let fScore: Double
 
     static func < (lhs: AStarEntry, rhs: AStarEntry) -> Bool {
-        lhs.fScore < rhs.fScore
+        // Total order: primarily by f-score (what the heap needs), with nodeId as a
+        // tiebreaker so the ordering is consistent with `==`. Without the tiebreaker,
+        // two entries with equal f-scores but different nodeIds would be neither `<`,
+        // `>`, nor `==`, violating Comparable's strict-weak-ordering contract.
+        if lhs.fScore != rhs.fScore {
+            return lhs.fScore < rhs.fScore
+        }
+        return lhs.nodeId < rhs.nodeId
     }
 
     static func == (lhs: AStarEntry, rhs: AStarEntry) -> Bool {

--- a/Shared/Storage/RoutingStore.swift
+++ b/Shared/Storage/RoutingStore.swift
@@ -193,7 +193,7 @@ final class RoutingStore: @unchecked Sendable {
         let bbox = BoundingBox(center: coordinate, radiusMeters: maxRadiusMetres)
         let candidates = try getNodesInBoundingBox(bbox)
 
-        return candidates.min(by: { a, b in
+        let nearest = candidates.min(by: { a, b in
             let distA = haversineDistance(
                 lat1: coordinate.latitude, lon1: coordinate.longitude,
                 lat2: a.latitude, lon2: a.longitude
@@ -204,6 +204,16 @@ final class RoutingStore: @unchecked Sendable {
             )
             return distA < distB
         })
+
+        // The bounding box extends to ~radius*sqrt(2) at its corners, so enforce the
+        // true radius here; otherwise a node well outside maxRadiusMetres could be
+        // accepted and "no nearby node" would be effectively unreachable.
+        guard let nearest = nearest else { return nil }
+        let nearestDist = haversineDistance(
+            lat1: coordinate.latitude, lon1: coordinate.longitude,
+            lat2: nearest.latitude, lon2: nearest.longitude
+        )
+        return nearestDist <= maxRadiusMetres ? nearest : nil
     }
 
     // MARK: - Edge Queries
@@ -518,7 +528,13 @@ final class RoutingStore: @unchecked Sendable {
                 }
             }
 
-            return bestResult
+            // Reject a snap whose trail distance exceeds the search radius, so callers
+            // get a clean "no trail nearby" result instead of a far-away match (the
+            // bounding box extends to ~radius*sqrt(2) at its corners).
+            guard let result = bestResult, result.distanceToTrail <= maxRadiusMetres else {
+                return nil
+            }
+            return result
         }
     }
 

--- a/Shared/Storage/TileStore.swift
+++ b/Shared/Storage/TileStore.swift
@@ -222,15 +222,52 @@ final class TileStore: @unchecked Sendable {
     /// - Returns: An array of (coordinate, data) tuples for each found tile.
     /// - Throws: Rethrows any unexpected database errors.
     func getTiles(in range: TileRange) throws -> [(TileCoordinate, Data)] {
-        var results: [(TileCoordinate, Data)] = []
-
-        for tile in range.allTiles() {
-            if let data = try? getTile(tile) {
-                results.append((tile, data))
+        try queue.sync {
+            guard let db = db else {
+                throw TileStoreError.databaseNotOpen
             }
-        }
 
-        return results
+            // Convert the XYZ y-range to TMS rows once. TMS flips the y-axis
+            // (tmsY = 2^z - 1 - y), so the min/max swap: the smallest XYZ y maps to
+            // the largest TMS row and vice versa.
+            let maxRow = (1 << range.zoom) - 1 - range.minY
+            let minRow = (1 << range.zoom) - 1 - range.maxY
+
+            // A single ranged SELECT with one prepared statement, rather than
+            // re-preparing and re-acquiring the serial queue once per tile.
+            let query = """
+                SELECT tile_column, tile_row, tile_data FROM tiles
+                WHERE zoom_level = ?
+                  AND tile_column BETWEEN ? AND ?
+                  AND tile_row BETWEEN ? AND ?
+                """
+            var statement: OpaquePointer?
+            guard sqlite3_prepare_v2(db, query, -1, &statement, nil) == SQLITE_OK else {
+                throw TileStoreError.databaseError(String(cString: sqlite3_errmsg(db)))
+            }
+            defer { sqlite3_finalize(statement) }
+
+            sqlite3_bind_int(statement, 1, Int32(range.zoom))
+            sqlite3_bind_int(statement, 2, Int32(range.minX))
+            sqlite3_bind_int(statement, 3, Int32(range.maxX))
+            sqlite3_bind_int(statement, 4, Int32(minRow))
+            sqlite3_bind_int(statement, 5, Int32(maxRow))
+
+            var results: [(TileCoordinate, Data)] = []
+            while sqlite3_step(statement) == SQLITE_ROW {
+                let column = Int(sqlite3_column_int(statement, 0))
+                let row = Int(sqlite3_column_int(statement, 1))
+                guard let blob = sqlite3_column_blob(statement, 2) else { continue }
+                let size = sqlite3_column_bytes(statement, 2)
+
+                // Convert the TMS row back to standard XYZ y.
+                let y = (1 << range.zoom) - 1 - row
+                let coordinate = TileCoordinate(x: column, y: y, z: range.zoom)
+                results.append((coordinate, Data(bytes: blob, count: Int(size))))
+            }
+
+            return results
+        }
     }
 
     // MARK: - Private Methods

--- a/Shared/Utilities/TrackCompression.swift
+++ b/Shared/Utilities/TrackCompression.swift
@@ -229,33 +229,55 @@ enum TrackCompression {
 
     /// Decompresses zlib-compressed data via Apple's Compression framework.
     ///
-    /// Allocates a destination buffer at 10x the compressed size to accommodate
-    /// the expected expansion ratio. Returns `nil` if decompression fails.
+    /// The destination buffer starts at 10x the compressed size and grows on
+    /// retry until the entire stream fits. This matters because
+    /// `compression_decode_buffer` does NOT report an error when the destination
+    /// is too small -- it simply returns the bytes that fit. A single fixed
+    /// multiplier would therefore silently truncate the track (dropping whole
+    /// 20-byte point records) on data that expands beyond the multiplier.
     ///
     /// - Parameter compressedData: Zlib-compressed data.
-    /// - Returns: The decompressed raw data, or `nil` if decompression fails.
+    /// - Returns: The complete decompressed data, or `nil` if decompression fails.
     private static func decompress(_ compressedData: Data) -> Data? {
-        // Estimate decompressed size: for our binary track data, typical ratio is ~2:1
-        // Use 10x as upper bound to be safe.
-        let destinationBufferSize = compressedData.count * decompressionBufferMultiplier
-        let destinationBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: destinationBufferSize)
-        defer { destinationBuffer.deallocate() }
+        guard !compressedData.isEmpty else { return nil }
 
-        let decompressedSize = compressedData.withUnsafeBytes { sourceBuffer -> Int in
-            guard let sourcePtr = sourceBuffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
-                return 0
+        var destinationBufferSize = compressedData.count * decompressionBufferMultiplier
+        // Ceiling guards against unbounded growth on malformed input while still
+        // comfortably exceeding any realistic zlib expansion ratio.
+        let maxBufferSize = max(destinationBufferSize, compressedData.count * 1024)
+
+        while true {
+            let destinationBuffer = UnsafeMutablePointer<UInt8>.allocate(capacity: destinationBufferSize)
+            defer { destinationBuffer.deallocate() }
+
+            let decompressedSize = compressedData.withUnsafeBytes { sourceBuffer -> Int in
+                guard let sourcePtr = sourceBuffer.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                    return 0
+                }
+                return compression_decode_buffer(
+                    destinationBuffer,
+                    destinationBufferSize,
+                    sourcePtr,
+                    compressedData.count,
+                    nil,
+                    COMPRESSION_ZLIB
+                )
             }
-            return compression_decode_buffer(
-                destinationBuffer,
-                destinationBufferSize,
-                sourcePtr,
-                compressedData.count,
-                nil,
-                COMPRESSION_ZLIB
-            )
-        }
 
-        guard decompressedSize > 0 else { return nil }
-        return Data(bytes: destinationBuffer, count: decompressedSize)
+            guard decompressedSize > 0 else { return nil }
+
+            // A result smaller than the buffer is guaranteed complete. If it
+            // exactly filled the buffer, output may have been truncated -- grow
+            // and retry until it fits or we hit the ceiling.
+            if decompressedSize < destinationBufferSize {
+                return Data(bytes: destinationBuffer, count: decompressedSize)
+            }
+            if destinationBufferSize >= maxBufferSize {
+                // Cannot prove completeness; treat as failure rather than return
+                // a possibly-truncated track.
+                return nil
+            }
+            destinationBufferSize = min(destinationBufferSize * 2, maxBufferSize)
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses a set of genuine bugs, logical errors, and performance issues found during a thorough code review across the routing, storage/tile, networking/P2P, OSM-parsing, location, and health subsystems. Each fix was committed separately and reviewed.

> Note: there is no Swift toolchain in this environment, so changes were verified by careful manual review rather than a compile/build. A local `xcodebuild` of both schemes before merge is recommended.

## Critical (crashes / corruption / policy)

- **Int16 overflow crash parsing HGT elevation tiles** — `(hi << 8)` trapped whenever the high byte was ≥ `0x80` (incl. the SRTM void marker `0x8000`), crashing on virtually every real elevation tile. Now assembles in `UInt16` and reinterprets the bit pattern. *(ElevationDataManager)*
- **SpO₂ displayed at 100×** (e.g. `9700%`) — `HKUnit.percent()` yields 0–100 but the value is stored as a fraction and the formatter multiplies by 100 again. Now divides by 100 on read. *(HealthKitManager)*
- **Tile-download rate limiter defeated under concurrency** — the throttle recorded its timestamp *after* sleeping, so concurrent actor callers read a stale value and fired as a burst (OSM/OpenTopoMap policy violation). Replaced with a reservation cursor advanced synchronously before suspension. *(TileDownloader)*

## High

- **Distorted distance-along-route in navigation** — the projection used raw lat/lon deltas (1° lon ≠ 1° lat), skewing progress/remaining-distance/next-turn on diagonal segments. Now scales longitude by `cos(latitude)`. *(RouteGuidance + iOSRouteGuidance)*
- **Silent zlib decompression truncation** — `compression_decode_buffer` doesn't error when the destination is too small; a fixed multiplier could drop OSM blocks / track points. Now verifies output length against `raw_size` (PBF) and grows-and-retries until provably complete. *(PBFParser + TrackCompression)*
- **Watch map texture cache never served hits** — every tile re-decoded its PNG and re-queried SQLite; the cache only consumed memory and used undefined dictionary order for eviction. Now reads the cache and uses true LRU. *(MapRenderer)*
- **P2P receiver temp-file leaks** — several guard/error paths returned without deleting the received temp file. Consolidated into a single `defer` cleanup. *(PeerTransferService)*
- **iOS GPS distance inflation** — low-accuracy (≥100 m) jitter points still added their raw distance to the total. Now anchors distance/elevation on the last high-accuracy point (points still recorded for visual continuity). *(iOSLocationManager)*

## Medium / Low

- **`TileStore.getTiles` O(n) statement churn** → single ranged `SELECT` with correct TMS row conversion. *(TileStore)*
- **Coordinate conversion hardening** — normalize longitude into [-180,180), clamp latitude to the Web Mercator limit, clamp x/y to valid range. *(TileCoordinate)*
- **Backward turn bearings on reverse-traversed edges** — geometry is stored canonically but traversed in either direction; bearing helpers now orient geometry by the traversal-start node id. *(TurnInstruction)*
- **`AStarEntry` Comparable** made a consistent total order (nodeId tiebreaker). *(RoutingEngine)*
- **Nearest node/trail snapping** now enforces the true search radius instead of accepting anything inside the bounding box. *(RoutingStore)*
- **GitHub 403 rate-limit** responses are now detected (Retry-After / `x-ratelimit-*`) and retried instead of surfacing a spurious auth failure. *(GitHubRouteService)*
- **Elevation tile cache** now evicts the genuine LRU entry instead of an arbitrary dictionary key. *(ElevationDataManager)*

## Verified non-issues (no change)

- **Turn-instruction node/edge alignment**: the `nodes.count == edges.count + 1` invariant holds through route concatenation, and the degenerate zero-edge route is already guarded — no misalignment occurs.
- **PBF malformed `keys_vals` tail**: the parser already degrades safely (nodes still parsed, only tags dropped on corrupt input) with no crash or geometry corruption.

## Test plan

- [ ] `xcodebuild` both schemes (iOS + watchOS) — no compiler available in this environment
- [ ] Manual: record a hike on iOS with degraded GPS, confirm distance no longer over-reports
- [ ] Manual: confirm SpO₂ badge shows e.g. `97%`
- [ ] Manual: download a region, confirm polite request pacing and panning performance on watch


---
_Generated by [Claude Code](https://claude.ai/code/session_01ERB9No222rfsFrpEQetu6J)_